### PR TITLE
手持ちのアイテムに関する修正

### DIFF
--- a/minecraft_msgs/msg/PlayerStatus.msg
+++ b/minecraft_msgs/msg/PlayerStatus.msg
@@ -12,4 +12,5 @@ uint16 air
 uint16 max_air
 string[] active_effects
 minecraft_msgs/Item[] inventory_items 
-minecraft_msgs/Item selected_item
+minecraft_msgs/Item main_hand_item
+minecraft_msgs/Item off_hand_item


### PR DESCRIPTION
https://github.com/minecraft-ros2/minecraft_msgs/issues/5 より selected_item の代わりに次の要素を追加。（実装内容は変わらず、変数名の変更）

- main_hand_item (旧 : selected_item)
- off_hand_item

それぞれの情報は [getItemInHand(net.minecraft.util.Hand)](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.16.5/net/minecraft/entity/LivingEntity.html#getItemInHand(net.minecraft.util.Hand)) に `MAIN_HAND` か `OFF_HAND` (net.minecraft.world.InteractionHand) のいずれかを指定することで取得される。